### PR TITLE
Modified `exchangeStars` function on `StarNotary` contract.

### DIFF
--- a/contracts/StarNotary.sol
+++ b/contracts/StarNotary.sol
@@ -33,7 +33,7 @@ contract StarNotary is ERC721 {
 
     // Putting an Star for sale (Adding the star tokenid into the mapping starsForSale, first verify that the sender is the owner)
     function putStarUpForSale(uint256 _tokenId, uint256 _price) public {
-        require(ownerOf(_tokenId) == msg.sender, "You can't sale the Star you don't owned");
+        require(ownerOf(_tokenId) == msg.sender, "You can't sell a Star you don't owned");
         starsForSale[_tokenId] = _price;
     }
 
@@ -57,17 +57,22 @@ contract StarNotary is ERC721 {
     }
 
     // Implement Task 1 lookUptokenIdToStarInfo
-    function lookUptokenIdToStarInfo (uint _tokenId) public view returns (string memory) {
+    function lookUptokenIdToStarInfo(uint _tokenId) public view returns (string memory) {
         //1. You should return the Star saved in tokenIdToStarInfo mapping
         return tokenIdToStarInfo[_tokenId];
     }
 
     // Implement Task 1 Exchange Stars function
     function exchangeStars(uint256 _tokenId1, uint256 _tokenId2) public {
-        //1. Passing to star tokenId you will need to check if the owner of _tokenId1 or _tokenId2 is the sender
-        //2. You don't have to check for the price of the token (star)
-        //3. Get the owner of the two tokens (ownerOf(_tokenId1), ownerOf(_tokenId1)
-        //4. Use _transferFrom function to exchange the tokens.
+        // Get the owner of each stars address:
+        address owner1 = ownerOf(_tokenId1);
+        address owner2 = ownerOf(_tokenId2);
+        // Require that the sender of the request is the owner of one of the stars:
+        bool isOwner = (owner1 == msg.sender || owner2 == msg.sender);
+        require(isOwner, "You can't exchange stars you don't own.");
+        // Exchange the star tokens between the users.
+        _transferFrom(owner1, owner2, _tokenId1);
+        _transferFrom(owner2, owner1, _tokenId2);
     }
 
     // Implement Task 1 Transfer Stars


### PR DESCRIPTION
- Modified `exchangeStars(uint _tokenId1, uint _tokenId2)` function in `StarNotary` contract to exchange star tokens between two user addresses.
- Modified `exchangeStars(uint _tokenId1, uint _tokenId2)` function in `StarNotary` contract to require that the senders address is the same as one of the star token owners address.
- Closes #7 